### PR TITLE
:memo: git tag after mint install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ localmint:
 	echo "COMMIT HASH is $(HASH)"
 	git tag $(HASH)
 	mint install file://$(shell pwd -P)@$(HASH)
+	git tag -d $(HASH)
 
 xcodeproj: 
 	swift package generate-xcodeproj


### PR DESCRIPTION
## What
Remove git tag after mint install 

## Why
It is failed for `$ git push origin --tags`